### PR TITLE
[zkFuzz] fix the under-constrained assign-operator around `out2calc`

### DIFF
--- a/circuits/LayoutEligibility.circom
+++ b/circuits/LayoutEligibility.circom
@@ -191,7 +191,7 @@ template LayoutEligibility(MAP_WIDTH, MAP_HEIGHT, MAX_HOUSE, MAX_HOUSE_WIDTH, MA
   type4num <== typeAccumulation[4][MAP_SIZE - 1];
 
   signal out1 <== type0num;
-  signal out2calc <-- out1;
+  signal out2calc <== out1;
   signal type1calc <== type1num;
   signal compare2 <-- type1calc * 2;
   type1calc * 2 === compare2;


### PR DESCRIPTION
Close #1 

Specifically, on [Line 194 of LayoutEligibility](https://github.com/wizicer/dark-factory/blob/fe499b3b8d83daaa6874b4c11536055d2b6e1a56/circuits/LayoutEligibility.circom#L194), it seems the `<--` operator is used instead of `<==`. Since the `<--` operator doesn’t impose constraints, it allows a malicious prover to substitute the right-hand value arbitrarily. 

I tested this with a small demo case using the template parameters: `LayoutEligibility(1, 1, 1, 1, 1, 1);`.

Here’s an example input (generated by our fuzzing tool):

```
LayourPaths[0] = 5
path[0] = 21888242871839275222246405745257275088548364400416034343698204186575808495546
pathMask[0] = 1
```

The expected output `rate` is 0, with `out1` also being 0. However, if Line 194 is modified from:

`signal out2calc <-- out1;`
to:
`signal out2calc <-- 4;`

all the constraints remain satisfied, but the rate changes to 4. This demonstrates that a malicious prover could create a bogus proof that would still pass verification.

To prevent this issue, I suggest changing Line 194 to `signal out2calc <== out1;`